### PR TITLE
Prevent public access to user.ini

### DIFF
--- a/v2-varnish/WordPress/WordPress
+++ b/v2-varnish/WordPress/WordPress
@@ -62,6 +62,10 @@ server {
     deny all;
   }
 
+  location ~ ^/\.user\.ini {
+    deny all;
+  }
+
   location ~/(wp-admin/|wp-login.php) {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
The “.user.ini” file that Wordfence creates can contain sensitive information, and public access to it should be restricted.

https://www.wordfence.com/help/firewall/optimizing-the-firewall/#hide-userini-nginx