### PR TITLE
Update ReverseProxy

### DIFF
--- a/v2-varnish/ReverseProxy/ReverseProxy
+++ b/v2-varnish/ReverseProxy/ReverseProxy
@@ -15,18 +15,7 @@ server {
     rewrite ^ https://$host$uri permanent;
   }
 
-  location ~ /.well-known {
-    auth_basic off;
-    allow all;
-  }
-
-  {{settings}}
-
-  add_header Cache-Control no-transform;
-
-  index index.html;
-
-  location / {
+  location @reverse_proxy {
     proxy_pass {{reverse_proxy_url}};
     proxy_http_version 1.1;
     proxy_set_header X-Forwarded-Host $host;
@@ -46,5 +35,21 @@ server {
     proxy_buffers 4 256k;
     proxy_busy_buffers_size 256k;
     proxy_temp_file_write_size 256k;
+  }
+
+  {{settings}}
+
+  add_header Cache-Control no-transform;
+
+  index index.html;
+
+  location ^~ /.well-known {
+    auth_basic off;
+    allow all;
+    try_files $uri @reverse_proxy;
+  }
+
+  location / {
+    try_files $uri @reverse_proxy;
   }
 }


### PR DESCRIPTION
Currently, if a service behind a reverse proxy site needs to obtain a SSL certificate using let's encrypt, the `/.well-known/acme-challenge/` routes are always captured by nginx and the request of the service fails. 

The change forwards all `/.well-known/` requests to the reverse proxy service except those, that are served by the file system directly.

This way a service can obtain it's own certificate (needed for services like owncloud, mailcow etc) or expose other `/.well-known` routes like webfinger or autodiscovery protocols.