### PR TITLE
Update Nodejs vhost

### DIFF
--- a/v2/Nodejs/Nodejs
+++ b/v2/Nodejs/Nodejs
@@ -11,9 +11,9 @@ server {
   {{nginx_access_log}}
   {{nginx_error_log}}
 
-  if ($scheme != "https") {
-    rewrite ^ https://$host$uri permanent;
-  }
+  #if ($scheme != "https") {
+  #  rewrite ^ https://$host$uri permanent;
+  #}
 
   location ~ /.well-known {
     auth_basic off;


### PR DESCRIPTION
The current rule to forward from http to https prevents issuing a Let's encrypt certificate.