### PR TITLE
Deny access to hidden files.

### DIFF
--- a/v2/WordPress/WordPress
+++ b/v2/WordPress/WordPress
@@ -21,6 +21,14 @@ server {
     allow all;
   }
 
+  location ~ /\. {
+    deny all;
+  }
+
+  location ~* /(?:uploads|files)/.*\.php$ {
+    deny all;
+  }
+
   {{settings}}
 
   try_files $uri $uri/ /index.php?$args;


### PR DESCRIPTION
 Deny all attempts to access hidden files 
 Keep logging the requests to parse later (or to pass to firewall 

Deny access to any files with a .php extension in the uploads directory Works in sub-directory installs and also in multisite network Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)