### PR TITLE
block Wordpress XML-RPC endpoint

### DIFF
--- a/v2-http3/WordPress/WordPress
+++ b/v2-http3/WordPress/WordPress
@@ -31,6 +31,10 @@ server {
     deny all;
   }
 
+  location = /xmlrpc.php {
+    deny all;
+  }
+
   location ~/(wp-admin/|wp-login.php) {
     #auth_basic "Restricted Area";
     #auth_basic_user_file /home/site-user/.htpasswd;

--- a/v2-varnish/WordPress/WordPress
+++ b/v2-varnish/WordPress/WordPress
@@ -27,6 +27,10 @@ server {
     deny all;
   }
 
+  location = /xmlrpc.php {
+    deny all;
+  }
+
   location ~/(wp-admin/|wp-login.php) {
     #auth_basic "Restricted Area";
     #auth_basic_user_file /home/site-user/.htpasswd;

--- a/v2/WordPress/WordPress
+++ b/v2/WordPress/WordPress
@@ -21,6 +21,10 @@ server {
     allow all;
   }
 
+  location = /xmlrpc.php {
+    deny all;
+  }
+
   {{settings}}
 
   try_files $uri $uri/ /index.php?$args;


### PR DESCRIPTION
The Wordpress xml-rpc endpoint is outdated, insecure and already replaced by the current json api endpoint and should therefore be blocked by default.