### PR TITLE
Exclude admin-ajax.php from authentication

### DIFF
--- a/v2-http3/WordPress/WordPress
+++ b/v2-http3/WordPress/WordPress
@@ -35,6 +35,10 @@ server {
     deny all;
   }
 
+  location ~* ^/wp-admin/admin-ajax\.php$ {
+    auth_basic off;
+  }
+
   location ~/(wp-admin/|wp-login.php) {
     #auth_basic "Restricted Area";
     #auth_basic_user_file /home/site-user/.htpasswd;

--- a/v2-varnish/WordPress/WordPress
+++ b/v2-varnish/WordPress/WordPress
@@ -31,6 +31,10 @@ server {
     deny all;
   }
 
+  location ~* ^/wp-admin/admin-ajax\.php$ {
+    auth_basic off;
+  }
+
   location ~/(wp-admin/|wp-login.php) {
     #auth_basic "Restricted Area";
     #auth_basic_user_file /home/site-user/.htpasswd;


### PR DESCRIPTION
This update excludes `admin-ajax.php` from Basic Auth in `/wp-admin/`. Some frontend functionality (like AJAX requests from themes and plugins) relies on `admin-ajax.php`, and restricting access can break site features. This change ensures that authentication is still enforced for `/wp-admin/` while allowing necessary AJAX requests to function properly.