### PR TITLE
Add `try_files` for `favicon.ico` for Contao

### DIFF
--- a/v2-http3/Contao/Contao 4
+++ b/v2-http3/Contao/Contao 4
@@ -53,6 +53,7 @@ server {
   location = /favicon.ico {
     log_not_found off;
     access_log off;
+    try_files $uri /index.php$is_args$args;
   }
 
   location = /robots.txt {

--- a/v2-varnish/Contao/Contao 4
+++ b/v2-varnish/Contao/Contao 4
@@ -47,6 +47,7 @@ server {
   location = /favicon.ico {
     log_not_found off;
     access_log off;
+    try_files $uri /index.php$is_args$args;
   }
 
   location = /robots.txt {

--- a/v2/Contao/Contao 4
+++ b/v2/Contao/Contao 4
@@ -47,6 +47,7 @@ server {
   location = /favicon.ico {
     log_not_found off;
     access_log off;
+    try_files $uri /index.php$is_args$args;
   }
 
   location = /robots.txt {


### PR DESCRIPTION
Contao also has a dynamic `/favicon.ico` route since Contao 4.9: https://github.com/contao/contao/pull/717

Just like the `/robots.txt` route we thus have to add `try_files` there as well.