### PR TITLE
Add Contao 5 vhost template (fixes #53)

### DIFF
--- a/v2-http3/Contao/Contao 5
+++ b/v2-http3/Contao/Contao 5
@@ -1,0 +1,76 @@
+#{"rootDirectory":"public","phpVersion":"8.3"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 quic;
+  listen 443 ssl;
+  listen [::]:443 quic;
+  listen [::]:443 ssl;
+  http2 on;
+  http3 off;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$request_uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  include /etc/nginx/global_settings;
+
+  location / {
+    index index.php;
+    try_files $uri @rewriteapp;
+  }
+
+  location @rewriteapp {
+    rewrite ^(.*)$ /index.php/$1 last;
+  }
+
+  location ~ ^/(app|app_dev|config|index|preview|install|contao-manager\.phar)\.php(/|$) {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+    try_files $uri /index.php$is_args$args;
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    add_header alt-svc 'h3=":443"; ma=86400';
+    expires max;
+    try_files $uri $uri/ /index.php$is_args$args;
+    access_log off;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}

--- a/v2-varnish/Contao/Contao 5
+++ b/v2-varnish/Contao/Contao 5
@@ -1,0 +1,69 @@
+#{"rootDirectory":"public","phpVersion":"8.3"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  location / {
+    index index.php;
+    try_files $uri @rewriteapp;
+  }
+
+  location @rewriteapp {
+    rewrite ^(.*)$ /index.php/$1 last;
+  }
+
+  location ~ ^/(app|app_dev|config|index|preview|install|contao-manager\.phar)\.php(/|$) {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+    try_files $uri /index.php$is_args$args;
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires max;
+    try_files $uri $uri/ /index.php$is_args$args;
+    access_log off;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}

--- a/v2/Contao/Contao 5
+++ b/v2/Contao/Contao 5
@@ -1,0 +1,69 @@
+#{"rootDirectory":"public","phpVersion":"8.3"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  location / {
+    index index.php;
+    try_files $uri @rewriteapp;
+  }
+
+  location @rewriteapp {
+    rewrite ^(.*)$ /index.php/$1 last;
+  }
+
+  location ~ ^/(app|app_dev|config|index|preview|install|contao-manager\.phar)\.php(/|$) {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_split_path_info ^(.+\.php)(/.*)$;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+  }
+
+  location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+    try_files $uri /index.php$is_args$args;
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires max;
+    try_files $uri $uri/ /index.php$is_args$args;
+    access_log off;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a **Contao 5** vhost template in `v2`, `v2-varnish`, and `v2-http3` alongside the existing Contao 4 template
- Uses the same nginx configuration as Contao 4 (compatible with Contao 4.8+ Managed Edition and Contao 5) with default PHP 8.3 for new Contao 5 sites
- Keeps the existing **Contao 4** template unchanged to avoid breaking current installations

Fixes #53

## Test plan
- [ ] Import templates via `clpctl vhost-templates:import`
- [ ] Create a Contao 5 site and verify nginx vhost is generated correctly
- [ ] Confirm Contao 4 template still works for existing sites