### PR TITLE
Add Sendy vhost templates for all variants

### DIFF
--- a/v1/Sendy/Sendy
+++ b/v1/Sendy/Sendy
@@ -1,0 +1,91 @@
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  if ($bad_bot = 1) {
+    return 403;
+  }
+
+  add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{basic_auth}}
+
+  index index.php index.html;
+
+  location / {
+    try_files $uri $uri/ $uri.html $uri.php$is_args$query_string;
+  }
+
+  location /l/ {
+    rewrite ^/l/([a-zA-Z0-9/]+)$ /l.php?i=$1 last;
+  }
+
+  location /t/ {
+    rewrite ^/t/([a-zA-Z0-9/]+)$ /t.php?i=$1 last;
+  }
+
+  location /w/ {
+    rewrite ^/w/([a-zA-Z0-9/]+)$ /w.php?i=$1 last;
+  }
+
+  location /r/ {
+    rewrite ^/r/([a-zA-Z0-9/]+)$ /r.php?i=$1 last;
+  }
+
+  location /unsubscribe/ {
+    rewrite ^/unsubscribe/(.*)$ /unsubscribe.php?i=$1 last;
+  }
+
+  location /subscribe/ {
+    rewrite ^/subscribe/(.*)$ /subscribe.php?i=$1 last;
+  }
+
+  location /confirm/ {
+    rewrite ^/confirm/(.*)$ /confirm.php?i=$1 last;
+  }
+
+  location ~ \.php$ {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files $uri =404;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    {{php_fpm_listener}}
+    {{php_settings}}
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires max;
+    access_log off;
+  }
+
+  location ~ /\.(ht|svn|git) {
+    deny all;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}

--- a/v1/Sendy/Sendy
+++ b/v1/Sendy/Sendy
@@ -18,7 +18,7 @@ server {
   add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
 
   if ($scheme != "https") {
-    rewrite ^ https://$host$uri permanent;
+    return 301 https://$host$request_uri;
   }
 
   location ~ /.well-known {

--- a/v1/Sendy/Sendy
+++ b/v1/Sendy/Sendy
@@ -21,7 +21,7 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  location ~ /.well-known {
+  location ^~ /.well-known/ {
     auth_basic off;
     allow all;
   }

--- a/v2-http3/Sendy/Sendy
+++ b/v2-http3/Sendy/Sendy
@@ -1,0 +1,95 @@
+#{"rootDirectory":"","phpVersion":"8.3"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 quic;
+  listen 443 ssl;
+  listen [::]:443 quic;
+  listen [::]:443 ssl;
+  http2 on;
+  http3 off;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$request_uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  include /etc/nginx/global_settings;
+
+  index index.php index.html;
+
+  location / {
+    try_files $uri $uri/ $uri.html $uri.php$is_args$query_string;
+  }
+
+  location /l/ {
+    rewrite ^/l/([a-zA-Z0-9/]+)$ /l.php?i=$1 last;
+  }
+
+  location /t/ {
+    rewrite ^/t/([a-zA-Z0-9/]+)$ /t.php?i=$1 last;
+  }
+
+  location /w/ {
+    rewrite ^/w/([a-zA-Z0-9/]+)$ /w.php?i=$1 last;
+  }
+
+  location /r/ {
+    rewrite ^/r/([a-zA-Z0-9/]+)$ /r.php?i=$1 last;
+  }
+
+  location /unsubscribe/ {
+    rewrite ^/unsubscribe/(.*)$ /unsubscribe.php?i=$1 last;
+  }
+
+  location /subscribe/ {
+    rewrite ^/subscribe/(.*)$ /subscribe.php?i=$1 last;
+  }
+
+  location /confirm/ {
+    rewrite ^/confirm/(.*)$ /confirm.php?i=$1 last;
+  }
+
+  location ~ \.php$ {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files $uri =404;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf|map|mjs)$ {
+    add_header Access-Control-Allow-Origin "*";
+    add_header alt-svc 'h3=":443"; ma=86400';
+    expires max;
+    access_log off;
+  }
+
+  location ~ /\.(ht|svn|git) {
+    deny all;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}

--- a/v2-http3/Sendy/Sendy
+++ b/v2-http3/Sendy/Sendy
@@ -22,7 +22,7 @@ server {
     rewrite ^ https://$host$request_uri permanent;
   }
 
-  location ~ /.well-known {
+  location ^~ /.well-known/ {
     auth_basic off;
     allow all;
   }

--- a/v2-varnish/Sendy/Sendy
+++ b/v2-varnish/Sendy/Sendy
@@ -18,7 +18,7 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  location ~ /.well-known {
+  location ^~ /.well-known/ {
     auth_basic off;
     allow all;
   }

--- a/v2-varnish/Sendy/Sendy
+++ b/v2-varnish/Sendy/Sendy
@@ -15,7 +15,7 @@ server {
   add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
 
   if ($scheme != "https") {
-    rewrite ^ https://$host$uri permanent;
+    return 301 https://$host$request_uri;
   }
 
   location ~ /.well-known {

--- a/v2-varnish/Sendy/Sendy
+++ b/v2-varnish/Sendy/Sendy
@@ -1,0 +1,88 @@
+#{"rootDirectory":"","phpVersion":"8.3"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  index index.php index.html;
+
+  location / {
+    try_files $uri $uri/ $uri.html $uri.php$is_args$query_string;
+  }
+
+  location /l/ {
+    rewrite ^/l/([a-zA-Z0-9/]+)$ /l.php?i=$1 last;
+  }
+
+  location /t/ {
+    rewrite ^/t/([a-zA-Z0-9/]+)$ /t.php?i=$1 last;
+  }
+
+  location /w/ {
+    rewrite ^/w/([a-zA-Z0-9/]+)$ /w.php?i=$1 last;
+  }
+
+  location /r/ {
+    rewrite ^/r/([a-zA-Z0-9/]+)$ /r.php?i=$1 last;
+  }
+
+  location /unsubscribe/ {
+    rewrite ^/unsubscribe/(.*)$ /unsubscribe.php?i=$1 last;
+  }
+
+  location /subscribe/ {
+    rewrite ^/subscribe/(.*)$ /subscribe.php?i=$1 last;
+  }
+
+  location /confirm/ {
+    rewrite ^/confirm/(.*)$ /confirm.php?i=$1 last;
+  }
+
+  location ~ \.php$ {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files $uri =404;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires max;
+    access_log off;
+  }
+
+  location ~ /\.(ht|svn|git) {
+    deny all;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}

--- a/v2/Sendy/Sendy
+++ b/v2/Sendy/Sendy
@@ -18,7 +18,7 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  location ~ /.well-known {
+  location ^~ /.well-known/ {
     auth_basic off;
     allow all;
   }

--- a/v2/Sendy/Sendy
+++ b/v2/Sendy/Sendy
@@ -15,7 +15,7 @@ server {
   add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
 
   if ($scheme != "https") {
-    rewrite ^ https://$host$uri permanent;
+    return 301 https://$host$request_uri;
   }
 
   location ~ /.well-known {

--- a/v2/Sendy/Sendy
+++ b/v2/Sendy/Sendy
@@ -1,0 +1,88 @@
+#{"rootDirectory":"","phpVersion":"8.1"}
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  {{ssl_certificate_key}}
+  {{ssl_certificate}}
+  {{server_name}}
+  {{root}}
+
+  {{nginx_access_log}}
+  {{nginx_error_log}}
+
+  add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive" always;
+
+  if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+  }
+
+  location ~ /.well-known {
+    auth_basic off;
+    allow all;
+  }
+
+  {{settings}}
+
+  index index.php index.html;
+
+  location / {
+    try_files $uri $uri/ $uri.html $uri.php$is_args$query_string;
+  }
+
+  location /l/ {
+    rewrite ^/l/([a-zA-Z0-9/]+)$ /l.php?i=$1 last;
+  }
+
+  location /t/ {
+    rewrite ^/t/([a-zA-Z0-9/]+)$ /t.php?i=$1 last;
+  }
+
+  location /w/ {
+    rewrite ^/w/([a-zA-Z0-9/]+)$ /w.php?i=$1 last;
+  }
+
+  location /r/ {
+    rewrite ^/r/([a-zA-Z0-9/]+)$ /r.php?i=$1 last;
+  }
+
+  location /unsubscribe/ {
+    rewrite ^/unsubscribe/(.*)$ /unsubscribe.php?i=$1 last;
+  }
+
+  location /subscribe/ {
+    rewrite ^/subscribe/(.*)$ /subscribe.php?i=$1 last;
+  }
+
+  location /confirm/ {
+    rewrite ^/confirm/(.*)$ /confirm.php?i=$1 last;
+  }
+
+  location ~ \.php$ {
+    include fastcgi_params;
+    fastcgi_intercept_errors on;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    try_files $uri =404;
+    fastcgi_read_timeout 3600;
+    fastcgi_send_timeout 3600;
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_pass 127.0.0.1:{{php_fpm_port}};
+    fastcgi_param PHP_VALUE "{{php_settings}}";
+  }
+
+  location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires max;
+    access_log off;
+  }
+
+  location ~ /\.(ht|svn|git) {
+    deny all;
+  }
+
+  if (-f $request_filename) {
+    break;
+  }
+}


### PR DESCRIPTION
Adds Nginx vhost templates for Sendy (https://sendy.co), a self-hosted email newsletter application, across all four CloudPanel variants: v1, v2, v2-http3, and v2-varnish.

Key configuration decisions:
- Single-block direct PHP-FPM (no Varnish) — Sendy's tracking endpoints (/l/, /t/, /w/, /r/) must process every request individually; caching would break click/open tracking
- Sendy-specific URL rewrites for tracking, subscription, and confirmation endpoints
- Global X-Robots-Tag noindex — Sendy is a backend mail sending tool that should not be indexed by search engines
- Blocks access to .ht, .svn, and .git files